### PR TITLE
Tweet modal

### DIFF
--- a/config/handlebars-helpers.js
+++ b/config/handlebars-helpers.js
@@ -7,6 +7,7 @@ module.exports = {
     }
     return options.inverse(this)
   },
+  
   moment: function (a) {
     moment.updateLocale('zh-tw', { meridiem: a })
     return moment(a).fromNow()

--- a/controllers/api/tweetServer.js
+++ b/controllers/api/tweetServer.js
@@ -1,0 +1,32 @@
+const helpers = require('../../_helpers')
+const db = require('../../models')
+const { sequelize } = db
+const { User, Tweet, Reply, Like, Followship } = db
+const moment = require('moment')
+
+const tweetController = {
+  getTweet: async (req, res) => {
+    try {
+      let tweet = await Tweet.findByPk(req.params.tweetId, {
+        include: [User]
+      })
+      tweet.dataValues.createdAt =  moment.updateLocale('zh-tw', { meridiem: tweet.dataValues.createdAt })
+      tweet.dataValues.createdAt =  moment(tweet.dataValues.createdAt).fromNow()
+
+      let loginUser = await User.findByPk(helpers.getUser(req).id, {
+        attributes: [ 'id', 'avatar']
+      })
+
+      let data = {
+        tweet,
+        loginUser,
+      }
+
+      return res.json(data)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+}
+
+module.exports = tweetController

--- a/controllers/pageController.js
+++ b/controllers/pageController.js
@@ -140,7 +140,7 @@ const pageController = {
     } catch (err) {
       console.error(err)
     }
-  }
+  },
 
   // getAdminTweets: async (req, res) => {
 

--- a/controllers/tweetController.js
+++ b/controllers/tweetController.js
@@ -111,12 +111,15 @@ const tweetController = {
 
       const pops = await userController.getPopular(req, res)
 
+      const loginUser = await userController.getLoginUser(req, res)
+
       return res.render('user', {
         tweet: tweet.toJSON(),
         replies: replies.map((reply) => reply.toJSON()),
         isLiked,
+        pops,
+        loginUser,
         tweetPage: true,
-        pops
       })
     } catch (err) {
       console.error(err)

--- a/package-lock.json
+++ b/package-lock.json
@@ -171,6 +171,14 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
+    "axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "requires": {
+        "follow-redirects": "^1.14.4"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -997,6 +1005,11 @@
       "requires": {
         "is-buffer": "~2.0.3"
       }
+    },
+    "follow-redirects": {
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
     },
     "form-data": {
       "version": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "axios": "^0.24.0",
     "bcrypt-nodejs": "0.0.3",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.18.3",

--- a/public/javascripts/layout.js
+++ b/public/javascripts/layout.js
@@ -3,7 +3,7 @@ const modal = document.querySelectorAll('.modal')
 const modalReply = document.querySelector('#modal-reply')
 
 // // 全畫面監聽器
-body.addEventListener('click', (event) => {
+body.addEventListener('click', async (event) => {
   let target = event.target
 
   if (target.classList.contains('close') || target.classList.contains('mask')) {
@@ -14,6 +14,61 @@ body.addEventListener('click', (event) => {
   } else if (target.classList.contains('commenting')) {
     // 如果按下個別"回覆"icon，開啟 replying modal
     // axios here to get tweet info
+    let tweetId = target.dataset.tweetid
+    if (!tweetId) tweetId = target.parentElement.dataset.tweetid
+    
+    let response = await axios.get(`http://localhost:3000/api/tweets/${tweetId}`)
+    const {tweet, loginUser} = response.data
+
+    let modalHtml = `
+    <div class="mask">
+      <div class="dialog">
+        <div class="dialog-header">
+          <a class="close"><i class='X-orange close'></i></a>
+        </div>
+        <div class="replyarea">
+
+          <div class="tweet">
+            <a>
+              <img class="thumbnail" src="${tweet.User.avatar}" alt="">
+            </a>
+            <div class="tweetcontent">
+              <a class="tweetuser">
+                <span class="name ellipsis">${tweet.User.name}</span>
+                <span class="at-name ellipsis">${tweet.User.account}</span>
+                <span class="timer ellipsis">${tweet.createdAt}</span>
+              </a>
+              <span class="tweetdescription" id="modal-reply-content">
+              ${tweet.description}
+              </span>
+              <span class="replyto">回覆給
+                <span class="at-name">@${tweet.User.account}</span>
+              </span>
+            </div>
+
+          </div>
+        </div>
+
+        <div class="postarea">
+          <a>
+            <img class="thumbnail" src="${loginUser.avatar}" alt="">
+          </a>
+          <form action="/tweets/${tweet.id}/replies" method="post" id="modal-reply-form" novalidate>
+            <input type="hidden" name="userId" value="${loginUser.id}">
+            <textarea name="comment" maxlength="140" cols="48" rows="2" placeholder="推你的回覆"
+              id="modal-reply-form-textarea" required></textarea>
+            <div class="foot">
+              <span class="d-none">內容不可空白</span>
+              <button type="summit" class="btn-fill">回覆</button>
+            </div>
+          </form>
+        </div>
+
+      </div>
+    </div>
+    `
+    modalReply.innerHTML = modalHtml
+    
     modalReply.classList.remove('d-none')
   }
 })

--- a/routes/apis.js
+++ b/routes/apis.js
@@ -3,6 +3,7 @@ const express = require('express')
 const router = express.Router()
 
 const userController = require('../controllers/api/userController')
+const tweetServer = require('../controllers/api/tweetServer')
 
 const authenticated = (req, res, next) => {
   if (helpers.ensureAuthenticated(req)) {
@@ -13,5 +14,6 @@ const authenticated = (req, res, next) => {
 
 router.get('/users/:userId', authenticated, userController.getEditModal)
 router.post('/users/:userId', authenticated, userController.updateUser)
+router.get('/tweets/:tweetId', authenticated, tweetServer.getTweet) // reply modal api
 
 module.exports = router

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -36,6 +36,7 @@
   </script>
   {{/if}}
 
+  <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
   <script src="/javascripts/layout.js"></script>
 </body>
 

--- a/views/partials/profileLikes.hbs
+++ b/views/partials/profileLikes.hbs
@@ -54,7 +54,7 @@
         {{this.description}}
       </button>
       <div class="action">
-        <button type="button" class="commenting" data-userId="{{../user.id}}">
+        <button type="button" class="commenting" data-tweetId="{{this.id}}">
           <i class='comment commenting'></i>
           {{this.replyCount}}
         </button>

--- a/views/partials/profileTweets.hbs
+++ b/views/partials/profileTweets.hbs
@@ -62,7 +62,7 @@
         {{this.description}}
       </button>
       <div class="action">
-        <button type="button" class="commenting" data-userId="{{../user.id}}">
+        <button type="button" class="commenting" data-tweetid="{{this.id}}">
           <i class='comment commenting'></i>
           {{this.replyCount}}
         </button>

--- a/views/partials/tweet.hbs
+++ b/views/partials/tweet.hbs
@@ -9,7 +9,7 @@
 
   <a class="tweetuser" href="/users/{{tweet.User.id}}/tweets">
     <span>
-      <img class="thumbnail" {{#if tweet.User.acatar}} src="{{tweet.User.avatar}}" alt="{{tweet.User.avatar}} avatar"
+      <img class="thumbnail" {{#if tweet.User.avatar}} src="{{tweet.User.avatar}}" alt="{{tweet.User.avatar}} avatar"
         {{/if}}>
     </span>
     <span>
@@ -41,7 +41,7 @@
     </div>
 
     <div class="action">
-      <button type="button" class="commenting" data-userId="{{user.id}}">
+      <button type="button" class="commenting" data-tweetid="{{tweet.id}}">
         <i class='comment lg commenting'></i>
       </button>
 

--- a/views/partials/tweets.hbs
+++ b/views/partials/tweets.hbs
@@ -29,7 +29,7 @@
         {{this.description}}
       </a>
       <div class="action">
-        <button type="button" class="commenting" data-userId="{{loginUser.id}}">
+        <button type="button" class="commenting" data-tweetid="{{this.id}}">
           <i class='comment commenting'></i>
           {{this.replyCount}}
         </button>

--- a/views/user.hbs
+++ b/views/user.hbs
@@ -76,7 +76,7 @@
         </div>
         <div class="postarea">
           <a>
-            <img class="thumbnail" src="/icons/avatar.svg" alt="">
+            <img class="thumbnail" src="{{loginUser.avatar}}" alt="">
           </a>
           <form action="/tweets" method="post" novalidate id="modal-post-form">
             <input type="hidden" name="userId" value="{{loginUser.id}}">
@@ -94,51 +94,7 @@
 
   {{!-- replying modal --}}
   <div class="modal d-none" id="modal-reply">
-    <div class="mask">
-      <div class="dialog">
-        <div class="dialog-header">
-          <a class="close"><i class='X-orange close'></i></a>
-        </div>
-        <div class="replyarea">
-
-          <div class="tweet">
-            <a>
-              <img class="thumbnail" src="/icons/avatar.svg" alt="">
-            </a>
-            <div class="tweetcontent">
-              <a class="tweetuser">
-                <span class="name ellipsis">Loading...</span>
-                <span class="at-name ellipsis">@Loading...</span>
-                <span class="timer ellipsis">Loading...</span>
-              </a>
-              <span class="tweetdescription" id="modal-reply-content">
-                Loading . . .
-              </span>
-              <span class="replyto">回覆給
-                <span class="at-name">@Loading...</span>
-              </span>
-            </div>
-
-          </div>
-        </div>
-
-        <div class="postarea">
-          <a>
-            <img class="thumbnail" src="/icons/avatar.svg" alt="">
-          </a>
-          <form action="/notyet" method="post" id="modal-reply-form" novalidate>
-            <input type="hidden" name="userId" value="{{user.id}}">
-            <textarea name="description" maxlength="140" cols="48" rows="2" placeholder="推你的回覆"
-              id="modal-reply-form-textarea" required></textarea>
-            <div class="foot">
-              <span class="d-none">內容不可空白</span>
-              <button type="summit" class="btn-fill">回覆</button>
-            </div>
-          </form>
-        </div>
-
-      </div>
-    </div>
+    {{!-- modal innerHTML 由layout.js 一併帶入  --}}
   </div>
 
   {{!-- editing modal --}}


### PR DESCRIPTION
* 新增一條api用以傳遞reply modal資料
* layout.js 全局監聽 reply modal，以axios接取 reply modal api 資料
* partials folder: tweets.hbs, tweet.hbs, profileTweets.hbs, profileLikes.hbs 新增 reply modal 需要的 data-set屬性
* 檢查了全部有 推文 按鈕出現的頁面，現在所有頁面都該按鈕都功能正常可使用 (皆使用loginUser至前端樣板)